### PR TITLE
Multiple link fixes regarding the default branch (master to main)

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -7,10 +7,10 @@ layout: toc
     <p class="lead">{{ site.title | escape | downcase }}</p>
 
     <p class="article-meta">
-        This <a href="{{ site.github.repository_url | append: '/blob/master/' | append: page.path }}">article</a>
-        and its <a href="{{ site.github.repository_url | append: '/blob/master/' | append: page.path | replace: '.md', '.tsx' }}">code</a> were
+        This <a href="{{ site.github.repository_url | append: '/blob/main/' | append: page.path }}">article</a>
+        and its <a href="{{ site.github.repository_url | append: '/blob/main/' | append: page.path | replace: '.md', '.tsx' }}">code</a> were
         first published on {{ page.published | date: site.date_format }}{% if page.modified %}
-        and <a href="{{ site.github.repository_url | append: '/commits/master/' | append: page.path }}">last modified</a>
+        and <a href="{{ site.github.repository_url | append: '/commits/main/' | append: page.path }}">last modified</a>
         on {{ page.modified | date: site.date_format }}{% endif %}.
         {% assign length = page.url | size | minus: 1 %}{% capture article %}{{ page.url | slice: 0, length }}{% endcapture %}
         If you like the article,

--- a/pages/email/email.md
+++ b/pages/email/email.md
@@ -2508,9 +2508,9 @@ Since you shouldn't enter your email password on a random website like this one,
 I recommend that you use the mode for submission only with demo accounts which you've created for this purpose.
 The password is stored in the [local storage](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API)
 of your browser without any protections until you [erase the history](/#history-of-values).
-Having said that, the tool is [open source](https://github.com/KasparEtter/ef1p/blob/master/code/tools/protocols/esmtp.tsx)
+Having said that, the tool is [open source](https://github.com/KasparEtter/ef1p/blob/main/code/tools/protocols/esmtp.tsx)
 like the rest of this website and if you don't trust me that this website is served from those files,
-you can also [build and run](https://github.com/KasparEtter/ef1p/blob/master/README.md) this website locally.
+you can also [build and run](https://github.com/KasparEtter/ef1p/blob/main/README.md) this website locally.
 The tool uses [Thunderbird's database](https://autoconfig.thunderbird.net/v1.1/)
 and [Google's DNS API](https://developers.google.com/speed/public-dns/docs/doh/json)
 to resolve the server you want to connect to and the [API by ipinfo.io](https://ipinfo.io/developers)
@@ -7164,7 +7164,7 @@ Unfortunately, there is [no JavaScript library](https://github.com/mathiasbynens
 to validate [internationalized domain names](#internationalized-domain-names).
 I've approximated the [IDNA2008 rules](https://tools.ietf.org/html/rfc5894#section-3.1.3)
 in the [Punycode tool](#punycode-encoding)
-[as follows](https://github.com/KasparEtter/ef1p/blob/master/code/tools/encodings/punycode.tsx):
+[as follows](https://github.com/KasparEtter/ef1p/blob/main/code/tools/encodings/punycode.tsx):
 `/^[\p{Letter}\p{Number}][\p{Letter}\p{Mark}\p{Number}\p{Join_Control}]*(?:-+[\p{Letter}\p{Number}][\p{Letter}\p{Mark}\p{Number}\p{Join_Control}]*)*(?:\.[\p{Letter}\p{Number}][\p{Letter}\p{Mark}\p{Number}\p{Join_Control}]*(?:-+[\p{Letter}\p{Number}][\p{Letter}\p{Mark}\p{Number}\p{Join_Control}]*)*)*$/u`.
 
 This regular expression uses [Unicode property escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes)

--- a/pages/index/index.md
+++ b/pages/index/index.md
@@ -436,7 +436,7 @@ But we'll see what the future holds.
 ### What software do you use to create the graphics?
 {:data-toc-text="Graphics tool"}
 
-I wrote [my own SVG framework](https://github.com/KasparEtter/ef1p/tree/master/code/svg)
+I wrote [my own SVG framework](https://github.com/KasparEtter/ef1p/tree/main/code/svg)
 because I couldn't find a solution which matched my needs.
 I wanted to be able to style the scalable vector graphics with the page-wide [CSS](https://en.wikipedia.org/wiki/CSS)
 so that [the theme can be toggled](#dark-and-light-mode) without having to replace the graphics.


### PR DESCRIPTION
While reading your website, e.g. [here](https://explained-from-first-principles.com/#what-software-do-you-use-to-create-the-graphics), I noticed an issue regarding a broken link to the Github `master` branch. Github shows the error message: "Branch not found, redirected to default branch.". I renamed all the links from `master` to `main` to fix this. I hope I got all of them.